### PR TITLE
Add double-quote to escaped characters

### DIFF
--- a/Text/JSONParser.hs
+++ b/Text/JSONParser.hs
@@ -47,7 +47,7 @@ parseEscapeChar = do
           Right charKey -> "\\"++[charKey]
     return (read ("'"++escapeSequence++"'") :: Char)  
     
-parseAsciiEscapeKey = oneOf "\\/bfnrt"
+parseAsciiEscapeKey = oneOf "\\\"/bfnrt"
 parseUnicodePointCode = replicateM 4 (satisfy isHexDigit)
     
 parseKeyValuePair = do


### PR DESCRIPTION
Allow for escaped double quotes to occur inside strings.
Currently an escaped double quote is not allowed inside a string despite it being a part of the [JSON grammar](https://www.json.org/json-en.html)

If we for example have the following example:
```haskell
import Text.JSONParser ( parser )
import Text.Parsec.Prim  ( parse )

main :: IO ()
main = do
    print $ parse parser "test" "\"And she said: \\\"Hello, world!\\\" and smiled\""
```

We would expect the output to be:
```console
Right (JSingle (JKeyString "And she said: \"Hello, world!\" and smiled"))
```

However, the parser instead reports an error:
```console
Left "test" (line 1, column 17):
unexpected "\""
expecting "u"
```

This commit fixes this by adding the double quote among the escaped characters.